### PR TITLE
feat: adding a PCA aggregator

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -53,6 +53,17 @@ each of shape ``(num_samples, hidden_dim)``, and returns a 1-d tensor of shape `
     vec = train_steering_vector(model, tokenizer, data, aggregator=norm_mean_aggregator)
 
 
+For the common use-case of PCA, you can use the built-in ``pca_aggregator`` function. This will find a steering vector
+by taking the first principal component of the delta between positive and negative activations. Unlike the default mean
+aggregator, the steering vector from PCA will always have norm of 1.
+
+.. code-block:: python
+
+    from steering_vectors import train_steering_vector, pca_aggregator
+
+    vec = train_steering_vector(model, tokenizer, data, aggregator=pca_aggregator)
+
+
 Manually patching and unpatching
 ''''''''''''''''''''''''''''''''
 

--- a/steering_vectors/__init__.py
+++ b/steering_vectors/__init__.py
@@ -10,15 +10,15 @@ from .layer_matching import (
 from .record_activations import record_activations
 from .steering_vector import PatchOperator, SteeringPatchHandle, SteeringVector
 from .train_steering_vector import (
-    Aggregator,
     SteeringVectorTrainingSample,
-    mean_aggregator,
     train_steering_vector,
 )
+from .aggregators import Aggregator, mean_aggregator, pca_aggregator
 
 __all__ = [
     "Aggregator",
     "mean_aggregator",
+    "pca_aggregator",
     "LayerType",
     "LayerMatcher",
     "ModelLayerConfig",

--- a/steering_vectors/aggregators.py
+++ b/steering_vectors/aggregators.py
@@ -1,0 +1,36 @@
+from typing import Callable
+
+from torch import Tensor
+import torch
+
+
+Aggregator = Callable[[Tensor, Tensor], Tensor]
+
+
+def mean_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+    """
+    The default aggregator, which computes the mean of the difference between the
+    positive and negative activations.
+    """
+    return (pos_acts - neg_acts).mean(dim=0)
+
+
+@torch.no_grad()
+def pca_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+    """
+    An aggregator that uses PCA to calculate a steering vector. This will always
+    have norm of 1.
+    """
+    deltas = pos_acts - neg_acts
+    neg_deltas = -1 * deltas
+    vec = _uncentered_pca(torch.cat([deltas, neg_deltas]), k=1)[:, 0]
+    # PCA might find the negative of the correct vector, so we need to check
+    # that the vec aligns with most of the deltas, and flip it if not.
+    sign = torch.sign(torch.mean(deltas @ vec))
+    return sign * vec
+
+
+def _uncentered_pca(data: Tensor, k: int = 1) -> Tensor:
+    # No need to center the data since we flip the data around the origin in pca_aggregator
+    u, _s, _v = torch.svd(torch.t(data))
+    return u[:, :k]

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
-from typing import Callable, NamedTuple, Optional
+from typing import NamedTuple, Optional
 
 import torch
 from torch import Tensor, nn
 from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase
+
+from steering_vectors.aggregators import Aggregator, mean_aggregator
 
 from .layer_matching import LayerType, ModelLayerConfig, guess_and_enhance_layer_config
 from .record_activations import record_activations
@@ -14,17 +16,6 @@ from .steering_vector import SteeringVector
 class SteeringVectorTrainingSample(NamedTuple):
     positive_prompt: str
     negative_prompt: str
-
-
-Aggregator = Callable[[Tensor, Tensor], Tensor]
-
-
-def mean_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
-    """
-    The default aggregator, which computes the mean of the difference between the
-    positive and negative activations.
-    """
-    return (pos_acts - neg_acts).mean(dim=0)
 
 
 @torch.no_grad()

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+from steering_vectors.aggregators import mean_aggregator, pca_aggregator
+from torch.nn.functional import cosine_similarity
+
+
+def test_pca_aggregator_with_single_difference() -> None:
+    delta = torch.randn(100)
+    pos = torch.randn(100)
+    neg = pos - delta
+
+    vec = pca_aggregator(pos.unsqueeze(0), neg.unsqueeze(0))
+    assert vec.shape == (100,)
+    assert vec.norm() == pytest.approx(1)
+    assert cosine_similarity(vec, delta, dim=0) == pytest.approx(1)
+
+
+def test_pca_aggregator_with_synth_data() -> None:
+    delta = torch.randn(100)
+    pos = torch.randn(50, 100)
+    noise = torch.randn(50, 100) * 0.2
+    neg = pos - delta.unsqueeze(0) + noise
+
+    vec = pca_aggregator(pos, neg)
+    assert vec.shape == (100,)
+    assert vec.norm() == pytest.approx(1)
+    assert cosine_similarity(vec, delta, dim=0) > 0.99
+
+
+def test_pca_aggregator_and_mean_aggregator_give_similar_results() -> None:
+    delta = torch.randn(100)
+    pos = torch.randn(50, 100)
+    noise = torch.randn(50, 100)
+    neg = pos - delta.unsqueeze(0) + noise
+
+    pca_vec = pca_aggregator(pos, neg)
+    mean_vec = mean_aggregator(pos, neg)
+    assert pca_vec.shape == (100,)
+    assert mean_vec.shape == (100,)
+    assert cosine_similarity(mean_vec, pca_vec, dim=0) > 0.99


### PR DESCRIPTION
This PR adds a PCA aggregator, usable like below:

```
from steering_vectors import pca_aggregator, train_steering_vector

vec = train_steering_vector(model, tokenizer, data, aggregator=pca_aggregator)
```