### PR TITLE
feat: Support selecting specific token indices when applying and training steering vector

### DIFF
--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -189,7 +189,7 @@ class SteeringVector:
 
 def _create_additive_hook(
     target_activation: Tensor,
-    token_indices: list[int] | slice | Tensor | None = None,
+    token_indices: list[int] | slice | Tensor,
     operator: PatchOperator | None = None,
 ) -> Any:
     """Create a hook function that adds the given target_activation to the model output"""
@@ -202,11 +202,9 @@ def _create_additive_hook(
             delta = operator(original_tensor, act)
         if isinstance(token_indices, Tensor):
             mask = token_indices
-        elif token_indices is not None:
+        else:
             mask = torch.zeros(original_tensor.shape[1])
             mask[token_indices] = 1
-        else:
-            mask = torch.ones(original_tensor.shape[1])
         mask = mask.reshape(1, -1, 1)
         mask = mask.to(original_tensor.device)
         original_tensor[None] = original_tensor + (mask * delta)

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -69,29 +69,18 @@ def train_steering_vector(
     else:
         sv_training_samples = training_samples  # type: ignore[assignment]
 
-    def get_token_index(
-        custom_idx: Optional[int], default_idx: int | Callable[[str], int], prompt: str
-    ) -> int:
-        if custom_idx is None:
-            if isinstance(default_idx, int):
-                return default_idx
-            else:
-                return default_idx(prompt)
-        else:
-            return custom_idx
-
     # TODO: batching
     for training_sample in tqdm(
         sv_training_samples,
         disable=not show_progress,
         desc="Training steering vector",
     ):
-        pos_index = get_token_index(
+        pos_index = _get_token_index(
             training_sample.read_positive_token_index,
             read_token_index,
             training_sample.positive_prompt,
         )
-        neg_index = get_token_index(
+        neg_index = _get_token_index(
             training_sample.read_negative_token_index,
             read_token_index,
             training_sample.negative_prompt,
@@ -152,3 +141,15 @@ def _extract_activations(
     for layer_num, activation in record.items():
         results[layer_num] = activation[-1][0, read_token_index].detach()
     return results
+
+
+def _get_token_index(
+    custom_idx: int | None, default_idx: int | Callable[[str], int], prompt: str
+) -> int:
+    if custom_idx is None:
+        if isinstance(default_idx, int):
+            return default_idx
+        else:
+            return default_idx(prompt)
+    else:
+        return custom_idx

--- a/tests/test_steering_vector.py
+++ b/tests/test_steering_vector.py
@@ -116,14 +116,6 @@ def test_SteeringVector_patch_activations_with_min_token_index(
     assert torch.equal(expected_hidden_state, patched_hidden_states[2][0, 5:])
 
 
-""" 
-verify that patch_activations works both when target indices is a list of indices or a mask
-target_token_indices: a list, slice, or tensor that is passed to patch_activations to select indices to patch
-non_target_token_indices: a list of token indices that should not be patched, used to test that they haven't changed after patching
-verification_token_indices: a list of token indices that should be patched, used to test that they have changed after patching. We can't use target_token_indices for this as it might be a mask.
-"""
-
-
 @pytest.mark.parametrize(
     "target_token_indices, non_target_token_indices, verification_token_indices",
     [
@@ -148,6 +140,11 @@ def test_SteeringVector_patch_activations_with_token_indices(
     non_target_token_indices: List[int],
     verification_token_indices: List[int],
 ) -> None:
+    """verify that patch_activations works both when target indices is a list of indices or a mask
+    target_token_indices: a list, slice, or tensor that is passed to patch_activations to select indices to patch
+    non_target_token_indices: a list of token indices that should not be patched, used to test that they haven't changed after patching
+    verification_token_indices: a list of token indices that should be patched, used to test that they have changed after patching. We can't use target_token_indices for this as it might be a mask.
+    """
     inputs = tokenizer(
         "What is cheesier than cheese? Nothing is cheesier than cheese",
         return_tensors="pt",

--- a/tests/test_train_steering_vector.py
+++ b/tests/test_train_steering_vector.py
@@ -1,7 +1,10 @@
 import torch
 from transformers import GPT2LMHeadModel, LlamaForCausalLM, PreTrainedTokenizer
 
-from steering_vectors.train_steering_vector import train_steering_vector
+from steering_vectors.train_steering_vector import (
+    train_steering_vector,
+    SteeringVectorTrainingSample,
+)
 from tests._original_caa.llama_wrapper import LlamaWrapper  # type: ignore
 
 
@@ -35,8 +38,8 @@ def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indi
         tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
         return tokenization.index("ĠX")
 
-    training_data: list[tuple[str, str, int | None, int | None]] = [
-        (
+    training_data: list[SteeringVectorTrainingSample] = [
+        SteeringVectorTrainingSample(
             "This is a short positive example. X <- probe here.",
             "This is a short negative example with different token length. X <- probe here.",
             get_x_index("This is a short positive example. X <- probe here."),
@@ -44,7 +47,7 @@ def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indi
                 "This is a short negative example with different token length. X <- probe here."
             ),
         ),
-        (
+        SteeringVectorTrainingSample(
             "Dummy text. This is a much longer positive example. X <- probe here. More dummy text.",
             "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text.",
             get_x_index(
@@ -55,10 +58,12 @@ def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indi
             ),
         ),
     ]
-    pos_examples = [p[0] for p in training_data]
-    neg_examples = [p[1] for p in training_data]
+    pos_examples = [p.positive_prompt for p in training_data]
+    neg_examples = [p.negative_prompt for p in training_data]
 
-    x_indices = [p[2] for p in training_data] + [p[3] for p in training_data]
+    x_indices = [p.read_positive_token_index for p in training_data] + [
+        p.read_negative_token_index for p in training_data
+    ]
     pos_acts = []
     neg_acts = []
 

--- a/tests/test_train_steering_vector.py
+++ b/tests/test_train_steering_vector.py
@@ -1,7 +1,11 @@
+from typing import Callable
+
+import pytest
 import torch
 from transformers import GPT2LMHeadModel, LlamaForCausalLM, PreTrainedTokenizer
 
 from steering_vectors.train_steering_vector import (
+    _get_token_index,
     train_steering_vector,
     SteeringVectorTrainingSample,
 )
@@ -237,3 +241,22 @@ def test_train_steering_vector_matches_original_caa(
         assert torch.allclose(
             steering_vector.layer_activations[layer], caa_vecs_by_layer[layer]
         )
+
+
+@pytest.mark.parametrize(
+    "custom_idx, default_idx, prompt, expected_output",
+    [
+        (None, 0, "prompt1", 0),
+        (1, 0, "prompt2", 1),
+        (None, lambda x: len(x), "prompt3", 7),
+        (2, lambda x: len(x), "prompt4", 2),
+    ],
+)
+def test_get_token_index(
+    custom_idx: int | None,
+    default_idx: int | Callable[[str], int],
+    prompt: str,
+    expected_output: int,
+) -> None:
+    actual_output = _get_token_index(custom_idx, default_idx, prompt)
+    assert actual_output == expected_output

--- a/tests/test_train_steering_vector.py
+++ b/tests/test_train_steering_vector.py
@@ -28,6 +28,120 @@ def test_train_steering_vector_reads_from_final_token_by_default(
         assert torch.allclose(vector, pos_vector - neg_vector)
 
 
+def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indices(
+    model: GPT2LMHeadModel, tokenizer: PreTrainedTokenizer
+) -> None:
+    def get_x_index(prompt: str) -> int:
+        tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
+        return tokenization.index("ĠX")
+
+    training_data = [
+        (
+            "This is a short positive example. X <- probe here.",
+            "This is a short negative example with different token length. X <- probe here.",
+            get_x_index("This is a short positive example. X <- probe here."),
+            get_x_index(
+                "This is a short negative example with different token length. X <- probe here."
+            ),
+        ),
+        (
+            "Dummy text. This is a much longer positive example. X <- probe here. More dummy text.",
+            "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text.",
+            get_x_index(
+                "Dummy text. This is a much longer positive example. X <- probe here. More dummy text."
+            ),
+            get_x_index(
+                "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text."
+            ),
+        ),
+    ]
+    pos_examples = [p[0] for p in training_data]
+    neg_examples = [p[1] for p in training_data]
+
+    x_indices = [p[2] for p in training_data] + [p[3] for p in training_data]
+    pos_acts = []
+    neg_acts = []
+
+    for pos_example in pos_examples:
+        pos_inputs = tokenizer(pos_example, return_tensors="pt")
+        pos_outputs = model(**pos_inputs, output_hidden_states=True)
+        pos_acts.append(pos_outputs.hidden_states)
+
+    for neg_example in neg_examples:
+        neg_inputs = tokenizer(neg_example, return_tensors="pt")
+        neg_outputs = model(**neg_inputs, output_hidden_states=True)
+        neg_acts.append(neg_outputs.hidden_states)
+
+    steering_vector = train_steering_vector(
+        model, tokenizer, training_data, layers=[2, 3, 4]
+    )
+
+    for layer, vector in steering_vector.layer_activations.items():
+        diffs = []
+        for pos_act, neg_act, pos_token, neg_token in zip(
+            pos_acts, neg_acts, x_indices[:2], x_indices[2:]
+        ):
+            pos_act = pos_act[layer + 1][0, pos_token, :]
+            neg_act = neg_act[layer + 1][0, neg_token, :]
+            diff = pos_act - neg_act
+            diffs.append(diff)
+        mean_diff = torch.stack(diffs).mean(dim=0)
+        assert torch.allclose(vector, mean_diff)
+
+
+def test_train_steering_vector_works_with_multiple_token_indices_by_passing_callable(
+    model: GPT2LMHeadModel, tokenizer: PreTrainedTokenizer
+) -> None:
+    def get_x_index(prompt: str) -> int:
+        tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
+        return tokenization.index("ĠX")
+
+    training_data = [
+        (
+            "This is a short positive example. X <- probe here.",
+            "This is a short negative example with different token length. X <- probe here.",
+        ),
+        (
+            "Dummy text. This is a much longer positive example. X <- probe here. More dummy text.",
+            "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text.",
+        ),
+    ]
+    pos_examples = [p[0] for p in training_data]
+    neg_examples = [p[1] for p in training_data]
+
+    x_indices = [get_x_index(p[0]) for p in training_data] + [
+        get_x_index(p[1]) for p in training_data
+    ]
+    pos_acts = []
+    neg_acts = []
+
+    for pos_example in pos_examples:
+        pos_inputs = tokenizer(pos_example, return_tensors="pt")
+        pos_outputs = model(**pos_inputs, output_hidden_states=True)
+        pos_acts.append(pos_outputs.hidden_states)
+
+    for neg_example in neg_examples:
+        neg_inputs = tokenizer(neg_example, return_tensors="pt")
+        neg_outputs = model(**neg_inputs, output_hidden_states=True)
+        neg_acts.append(neg_outputs.hidden_states)
+
+    steering_vector = train_steering_vector(
+        model, tokenizer, training_data, layers=[2, 3, 4], read_token_index=get_x_index
+    )
+
+    for layer, vector in steering_vector.layer_activations.items():
+        diffs = []
+        for pos_act, neg_act, pos_token, neg_token in zip(
+            pos_acts, neg_acts, x_indices[:2], x_indices[2:]
+        ):
+            pos_act = pos_act[layer + 1][0, pos_token, :]
+            neg_act = neg_act[layer + 1][0, neg_token, :]
+            diff = pos_act - neg_act
+            diffs.append(diff)
+        mean_diff = torch.stack(diffs).mean(dim=0)
+        assert torch.allclose(vector, mean_diff)
+
+
 def test_train_steering_vector_custom_aggregator(
     model: GPT2LMHeadModel, tokenizer: PreTrainedTokenizer
 ) -> None:

--- a/tests/test_train_steering_vector.py
+++ b/tests/test_train_steering_vector.py
@@ -35,7 +35,7 @@ def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indi
         tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
         return tokenization.index("ĠX")
 
-    training_data = [
+    training_data: list[tuple[str, str, int | None, int | None]] = [
         (
             "This is a short positive example. X <- probe here.",
             "This is a short negative example with different token length. X <- probe here.",


### PR DESCRIPTION
This PR adds support for selecting specific token indices when applying a steering vector, and for training steering vectors at different token indices for different prompts.

### Steering at specific indices
 A `token_indices` parameter was added to the `apply` and `patch_activations` methods of `steering_vector`. This lets the user select specific token indices at which a steering vector should be applied. `token_indices` can be either: 
- a list or list slice of integers, containing the indices at which to apply steering.
- a tensor mask of 0s and 1s, where 1s denote the positions at which to apply steering.

The `min_token_index` parameter for `apply` and `patch_activations` is still supported. Passing `min_token_index=n` is equivalent to passing `token_indices=slice(n,None)`

**Example**
```
# the following will apply the steering vector at token indices 2, 4, and 7
target_token_indices = [2, 4, 7]
steering_vector.patch_activations(model, token_indices=target_token_indices)

# equivalently, token_indices can be a mask
target_token_indices = torch.tensor([1 if i in [2, 4, 7] else 0 for i in range(input_length)]
steering_vector.patch_activations(model, token_indices=target_token_indices)
```

### Training at different indices for different prompts
_Note: Updated on Feb 1st 2024_
There are two ways of passing custom indices to `train_steering_vector`.
- Via training data: `SteeringVectorTrainingSample` now optionally takes a `read_positive_token_index` and `read_negative_token_index`. The `training_data` argument of `train_steering_vector` can now also be a 4-tuple, with the last two values being the index of the positive and negative example respectively. 
- Via the token index argument: The `read_token_index` argument can now be a callable, mapping prompts to indices. It can still be an int, and by default will still be -1.

**Example using training data**
```
def get_x_index(prompt: str) -> int:
        tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
        return tokenization.index("ĠX")

training_data = [
        (
            "This is a short positive example. X <- probe here.",
            "This is a short negative example with different token length. X <- probe here.",
            get_x_index("This is a short positive example. X <- probe here."),
            get_x_index(
                "This is a short negative example with different token length. X <- probe here."
            ),
        ),
        (
            "Dummy text. This is a much longer positive example. X <- probe here. More dummy text.",
            "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text.",
            get_x_index(
                "Dummy text. This is a much longer positive example. X <- probe here. More dummy text."
            ),
            get_x_index(
                "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text."
            ),
        ),
    ]

steering_vector = train_steering_vector(
        model, tokenizer, training_data, layers=[2, 3, 4]
)
```

**Example using read_token_index data**
```
def get_x_index(prompt: str) -> int:
        tokenization = tokenizer.convert_ids_to_tokens(tokenizer.encode(prompt))
        return tokenization.index("ĠX")

training_data = [
        (
            "This is a short positive example. X <- probe here.",
            "This is a short negative example with different token length. X <- probe here.",
        ),
        (
            "Dummy text. This is a much longer positive example. X <- probe here. More dummy text.",
            "Dummy text. This is a much longer negative example with different token length. X <- probe here. More dummy text.",
        ),
    ]

# note how the get_x_index function is passed to train_steering_vector
steering_vector = train_steering_vector(
        model, tokenizer, training_data, layers=[2, 3, 4], read_token_index=get_x_index
)
```
