### PR TITLE
feat: Add aggregators for logistic and linear regression

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -61,7 +61,17 @@ aggregator, the steering vector from PCA will always have norm of 1.
 
     from steering_vectors import train_steering_vector, pca_aggregator
 
-    vec = train_steering_vector(model, tokenizer, data, aggregator=pca_aggregator)
+    vec = train_steering_vector(model, tokenizer, data, aggregator=pca_aggregator())
+
+
+There is also a built-in logistic linear regression aggregator, which will find a steering vector by using scikit-learn's logistic
+regression model.
+
+.. code-block:: python
+
+    from steering_vectors import train_steering_vector, logistic_aggregator
+
+    vec = train_steering_vector(model, tokenizer, data, aggregator=logistic_aggregator())
 
 
 Manually patching and unpatching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = "MIT"
 python = "^3.10"
 transformers = "^4.35.2"
 tqdm = "^4.1.0"
+scikit-learn = "^1.4.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,3 +30,6 @@ ignore_missing_imports = True
 
 [mypy-tokenizers.*]
 ignore_missing_imports = True
+
+[mypy-sklearn.*]
+ignore_missing_imports = True

--- a/steering_vectors/__init__.py
+++ b/steering_vectors/__init__.py
@@ -17,7 +17,6 @@ from .aggregators import (
     Aggregator,
     mean_aggregator,
     pca_aggregator,
-    linear_aggregator,
     logistic_aggregator,
 )
 
@@ -25,7 +24,6 @@ __all__ = [
     "Aggregator",
     "mean_aggregator",
     "pca_aggregator",
-    "linear_aggregator",
     "logistic_aggregator",
     "LayerType",
     "LayerMatcher",

--- a/steering_vectors/__init__.py
+++ b/steering_vectors/__init__.py
@@ -13,12 +13,20 @@ from .train_steering_vector import (
     SteeringVectorTrainingSample,
     train_steering_vector,
 )
-from .aggregators import Aggregator, mean_aggregator, pca_aggregator
+from .aggregators import (
+    Aggregator,
+    mean_aggregator,
+    pca_aggregator,
+    linear_aggregator,
+    logistic_aggregator,
+)
 
 __all__ = [
     "Aggregator",
     "mean_aggregator",
     "pca_aggregator",
+    "linear_aggregator",
+    "logistic_aggregator",
     "LayerType",
     "LayerMatcher",
     "ModelLayerConfig",

--- a/steering_vectors/aggregators.py
+++ b/steering_vectors/aggregators.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Any, Callable
 
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from torch import Tensor
@@ -9,47 +9,54 @@ import torch.nn.functional as F
 Aggregator = Callable[[Tensor, Tensor], Tensor]
 
 
-@torch.no_grad()
-def linear_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
-    """
-    An aggregator that uses linear regression to calculate a steering vector.
-    """
-    return _get_normalized_regression_coef(
-        pos_acts, neg_acts, LinearRegression(fit_intercept=False)
-    )
-
-
-@torch.no_grad()
-def logistic_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+def logistic_aggregator(sklearn_kwargs: dict[str, Any] | None = None) -> Aggregator:
     """
     An aggregator that uses logistic regression to calculate a steering vector.
+
+    Args:
+        sklearn_kwargs: keyword arguments to pass to the scikit-learn LogisticRegression constructor.
     """
-    return _get_normalized_regression_coef(
-        pos_acts, neg_acts, LogisticRegression(fit_intercept=False)
-    )
+
+    @torch.no_grad()
+    def _logistic_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+        return _get_normalized_regression_coef(
+            pos_acts,
+            neg_acts,
+            LogisticRegression(fit_intercept=False, **(sklearn_kwargs or {})),
+        )
+
+    return _logistic_aggregator
 
 
-def mean_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+def mean_aggregator() -> Aggregator:
     """
     The default aggregator, which computes the mean of the difference between the
     positive and negative activations.
     """
-    return (pos_acts - neg_acts).mean(dim=0)
+
+    def _mean_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+        return (pos_acts - neg_acts).mean(dim=0)
+
+    return _mean_aggregator
 
 
-@torch.no_grad()
-def pca_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+def pca_aggregator() -> Aggregator:
     """
     An aggregator that uses PCA to calculate a steering vector. This will always
     have norm of 1.
     """
-    deltas = pos_acts - neg_acts
-    neg_deltas = -1 * deltas
-    vec = _uncentered_pca(torch.cat([deltas, neg_deltas]), k=1)[:, 0]
-    # PCA might find the negative of the correct vector, so we need to check
-    # that the vec aligns with most of the deltas, and flip it if not.
-    sign = torch.sign(torch.mean(deltas @ vec))
-    return sign * vec
+
+    @torch.no_grad()
+    def _pca_aggregator(pos_acts: Tensor, neg_acts: Tensor) -> Tensor:
+        deltas = pos_acts - neg_acts
+        neg_deltas = -1 * deltas
+        vec = _uncentered_pca(torch.cat([deltas, neg_deltas]), k=1)[:, 0]
+        # PCA might find the negative of the correct vector, so we need to check
+        # that the vec aligns with most of the deltas, and flip it if not.
+        sign = torch.sign(torch.mean(deltas @ vec))
+        return sign * vec
+
+    return _pca_aggregator
 
 
 def _get_normalized_regression_coef(
@@ -73,7 +80,7 @@ def _get_normalized_regression_coef(
         .numpy(),
     )
 
-    coef = torch.tensor([reg.coef_]).to(pos_acts.device).to(pos_acts.dtype)
+    coef = torch.tensor([reg.coef_]).to(pos_acts.device, dtype=pos_acts.dtype)
     normalized_coef = F.normalize(coef, dim=-1)
 
     return normalized_coef.view(-1).clone()

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -29,7 +29,7 @@ def train_steering_vector(
     move_to_cpu: bool = False,
     read_token_index: int = -1,
     show_progress: bool = False,
-    aggregator: Aggregator = mean_aggregator,
+    aggregator: Aggregator = mean_aggregator(),
     # TODO: add more options to control training
 ) -> SteeringVector:
     """

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,7 +1,41 @@
 import pytest
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from steering_vectors.aggregators import (
+    linear_aggregator,
+    logistic_aggregator,
+    mean_aggregator,
+    pca_aggregator,
+)
 import torch
-from steering_vectors.aggregators import mean_aggregator, pca_aggregator
 from torch.nn.functional import cosine_similarity
+
+
+def test_linear_aggregator() -> None:
+    pos = torch.randn(64, 100)
+    neg = -1 * torch.randn(64, 100)
+
+    reg = LinearRegression(fit_intercept=False).fit(
+        torch.cat([pos, neg]).numpy(),
+        torch.cat([torch.ones(pos.shape[0]), -1 * torch.ones(neg.shape[0])]).numpy(),
+    )
+    expected_vec = torch.nn.functional.normalize(torch.tensor([reg.coef_]), dim=0)
+
+    vec = linear_aggregator(pos, neg)
+    assert torch.allclose(vec, expected_vec)
+
+
+def test_logistic_aggregator() -> None:
+    pos = torch.randn(64, 100)
+    neg = -1 * torch.randn(64, 100)
+
+    reg = LogisticRegression(fit_intercept=False).fit(
+        torch.cat([pos, neg]).numpy(),
+        torch.cat([torch.ones(pos.shape[0]), -1 * torch.ones(neg.shape[0])]).numpy(),
+    )
+    expected_vec = torch.nn.functional.normalize(torch.tensor([reg.coef_]), dim=0)
+
+    vec = logistic_aggregator(pos, neg)
+    assert torch.allclose(vec, expected_vec)
 
 
 def test_pca_aggregator_with_single_difference() -> None:

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,6 +1,5 @@
 import pytest
 from steering_vectors.aggregators import (
-    linear_aggregator,
     logistic_aggregator,
     mean_aggregator,
     pca_aggregator,
@@ -9,24 +8,26 @@ import torch
 from torch.nn.functional import cosine_similarity
 
 
-def test_linear_aggregator() -> None:
-    delta = torch.randn(100)
-    pos = torch.randn(64, 100)
-    neg = pos - delta  # no noise because linear regression can't handle it
-
-    vec = linear_aggregator(pos, neg)
-    assert vec.shape == (100,)
-    assert vec.norm() == pytest.approx(1)
-    assert cosine_similarity(vec, delta, dim=0) == pytest.approx(1)
-
-
 def test_logistic_aggregator() -> None:
     delta = torch.randn(100)
     pos = torch.randn(64, 100)
     noise = torch.randn(64, 100) * 0.2
     neg = pos - delta + noise
 
-    vec = logistic_aggregator(pos, neg)
+    vec = logistic_aggregator()(pos, neg)
+    assert vec.shape == (100,)
+    assert vec.norm() == pytest.approx(1)
+    assert cosine_similarity(vec, delta, dim=0) > 0.99
+
+
+def test_logistic_aggregator_with_custom_sklearn_params() -> None:
+    delta = torch.randn(100)
+    pos = torch.randn(64, 100)
+    noise = torch.randn(64, 100) * 0.2
+    neg = pos - delta + noise
+    aggregator = logistic_aggregator(sklearn_kwargs={"penalty": None, "max_iter": 50})
+
+    vec = aggregator(pos, neg)
     assert vec.shape == (100,)
     assert vec.norm() == pytest.approx(1)
     assert cosine_similarity(vec, delta, dim=0) > 0.99
@@ -37,7 +38,7 @@ def test_pca_aggregator_with_single_difference() -> None:
     pos = torch.randn(100)
     neg = pos - delta
 
-    vec = pca_aggregator(pos.unsqueeze(0), neg.unsqueeze(0))
+    vec = pca_aggregator()(pos.unsqueeze(0), neg.unsqueeze(0))
     assert vec.shape == (100,)
     assert vec.norm() == pytest.approx(1)
     assert cosine_similarity(vec, delta, dim=0) == pytest.approx(1)
@@ -49,7 +50,7 @@ def test_pca_aggregator_with_synth_data() -> None:
     noise = torch.randn(50, 100) * 0.2
     neg = pos - delta.unsqueeze(0) + noise
 
-    vec = pca_aggregator(pos, neg)
+    vec = pca_aggregator()(pos, neg)
     assert vec.shape == (100,)
     assert vec.norm() == pytest.approx(1)
     assert cosine_similarity(vec, delta, dim=0) > 0.99
@@ -61,8 +62,8 @@ def test_pca_aggregator_and_mean_aggregator_give_similar_results() -> None:
     noise = torch.randn(50, 100)
     neg = pos - delta.unsqueeze(0) + noise
 
-    pca_vec = pca_aggregator(pos, neg)
-    mean_vec = mean_aggregator(pos, neg)
+    pca_vec = pca_aggregator()(pos, neg)
+    mean_vec = mean_aggregator()(pos, neg)
     assert pca_vec.shape == (100,)
     assert mean_vec.shape == (100,)
     assert cosine_similarity(mean_vec, pca_vec, dim=0) > 0.99


### PR DESCRIPTION
Adds aggregator functions that find a steering vector using linear or logistic regression. To follow the convention of the library, when `train_steering_vector` is called with a regression aggregator, the `training_samples` should be a list of tuples (positively_labeled_example, negatively_labeled_example).

**Example**
```
from steering_vectors import linear_aggregator, logistic_aggregator

# train steering vector with linear regession
vec1 = train_steering_vector(model, tokenizer, data, aggregator=linear_aggregator)

# train steering vector with logistic regession
vec2 = train_steering_vector(model, tokenizer, data, aggregator=logistic_aggregator)
```