### PR TITLE
feat: renaming prompts to strs in SteeringVectorTrainingSample

### DIFF
--- a/steering_vectors/__init__.py
+++ b/steering_vectors/__init__.py
@@ -1,5 +1,11 @@
 __version__ = "0.7.0"
 
+from .aggregators import (
+    Aggregator,
+    logistic_aggregator,
+    mean_aggregator,
+    pca_aggregator,
+)
 from .layer_matching import (
     LayerMatcher,
     LayerType,
@@ -9,16 +15,7 @@ from .layer_matching import (
 )
 from .record_activations import record_activations
 from .steering_vector import PatchOperator, SteeringPatchHandle, SteeringVector
-from .train_steering_vector import (
-    SteeringVectorTrainingSample,
-    train_steering_vector,
-)
-from .aggregators import (
-    Aggregator,
-    mean_aggregator,
-    pca_aggregator,
-    logistic_aggregator,
-)
+from .train_steering_vector import SteeringVectorTrainingSample, train_steering_vector
 
 __all__ = [
     "Aggregator",

--- a/steering_vectors/aggregators.py
+++ b/steering_vectors/aggregators.py
@@ -1,10 +1,9 @@
 from typing import Any, Callable
 
-from sklearn.linear_model import LinearRegression, LogisticRegression
-from torch import Tensor
 import torch
 import torch.nn.functional as F
-
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from torch import Tensor
 
 Aggregator = Callable[[Tensor, Tensor], Tensor]
 

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -16,8 +16,8 @@ from .steering_vector import SteeringVector
 
 @dataclass
 class SteeringVectorTrainingSample:
-    positive_prompt: str
-    negative_prompt: str
+    positive_str: str
+    negative_str: str
     read_positive_token_index: Optional[int] = None
     read_negative_token_index: Optional[int] = None
 
@@ -43,7 +43,7 @@ def train_steering_vector(
         model: The model to train the steering vector for
         tokenizer: The tokenizer to use
         training_samples: A list of training samples, where each sample is a tuple of
-            (positive_prompt, negative_prompt). The steering vector approximate the
+            (positive_str, negative_str). The steering vector approximate the
             difference between the positive prompt and negative prompt activations.
         layers: A list of layer numbers to train the steering vector on. If None, train
             on all layers.
@@ -78,17 +78,17 @@ def train_steering_vector(
         pos_index = _get_token_index(
             training_sample.read_positive_token_index,
             read_token_index,
-            training_sample.positive_prompt,
+            training_sample.positive_str,
         )
         neg_index = _get_token_index(
             training_sample.read_negative_token_index,
             read_token_index,
-            training_sample.negative_prompt,
+            training_sample.negative_str,
         )
         pos_acts = _extract_activations(
             model,
             tokenizer,
-            training_sample.positive_prompt,
+            training_sample.positive_str,
             layer_type=layer_type,
             layer_config=layer_config,
             layers=layers,
@@ -97,7 +97,7 @@ def train_steering_vector(
         neg_acts = _extract_activations(
             model,
             tokenizer,
-            training_sample.negative_prompt,
+            training_sample.negative_str,
             layer_type=layer_type,
             layer_config=layer_config,
             layers=layers,

--- a/tests/test_aggregators.py
+++ b/tests/test_aggregators.py
@@ -1,11 +1,12 @@
 import pytest
+import torch
+from torch.nn.functional import cosine_similarity
+
 from steering_vectors.aggregators import (
     logistic_aggregator,
     mean_aggregator,
     pca_aggregator,
 )
-import torch
-from torch.nn.functional import cosine_similarity
 
 
 def test_logistic_aggregator() -> None:

--- a/tests/test_train_steering_vector.py
+++ b/tests/test_train_steering_vector.py
@@ -5,9 +5,9 @@ import torch
 from transformers import GPT2LMHeadModel, LlamaForCausalLM, PreTrainedTokenizer
 
 from steering_vectors.train_steering_vector import (
+    SteeringVectorTrainingSample,
     _get_token_index,
     train_steering_vector,
-    SteeringVectorTrainingSample,
 )
 from tests._original_caa.llama_wrapper import LlamaWrapper  # type: ignore
 
@@ -62,8 +62,8 @@ def test_train_steering_vector_works_with_multiple_token_indices_by_passing_indi
             ),
         ),
     ]
-    pos_examples = [p.positive_prompt for p in training_data]
-    neg_examples = [p.negative_prompt for p in training_data]
+    pos_examples = [p.positive_str for p in training_data]
+    neg_examples = [p.negative_str for p in training_data]
 
     x_indices = [p.read_positive_token_index for p in training_data] + [
         p.read_negative_token_index for p in training_data


### PR DESCRIPTION
This PR renames the `_prompt` fields  on `SteeringVectorTrainingSample` to `_str` to be more clear about what they are.

**Note**: This PR also has formatting changes from `isort`, which unfortunately wasn't been checked in CI. This is fixed in #28, so once that's merged this won't be a problem moving-forward.

closes #16