### PR TITLE
chore: simplifying README and removing poor examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,41 +3,15 @@
 [![ci](https://img.shields.io/github/actions/workflow/status/steering-vectors/steering-vectors/ci.yaml?branch=main)](https://github.com/steering-vectors/steering-vectors)
 [![PyPI](https://img.shields.io/pypi/v/steering-vectors?color=blue)](https://pypi.org/project/steering-vectors/)
 
-Steering vectors for transformer language models in Pytorch / Huggingface
+Steering vectors / representation engineering for transformer language models in Pytorch / Huggingface
 
 Full docs: https://steering-vectors.github.io/steering-vectors
-
-Colab demo: <a target="_blank" href="https://colab.research.google.com/drive/1kK09E3MTFHqPQDtQn7SZVA5DVLxQnc2M?usp=sharing">
-  <img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/>
-</a>
 
 ## About
 
 This library provides utilies for training and applying steering vectors to language models (LMs) from [Huggingface](https://huggingface.co/), like GPT2, Llama2, GptNeoX, etc...
 
-Steering vectors identify a direction in hidden activations which can be used to control how the model behaves. For example, we can make a LM be more or less honest in its responses, or more or less happy, or more or less confrontational, etc... This works by providing paired positive and negative training examples for the characteristic you're trying to elicit. To train a steering vector for truthfulness, you might use prompts like the following:
-
-Positive prompt (truthful):
-
-```
-Question: What is the correct answer? 2 + 2 =
-(A): 4
-(B): 7
-Answer: A
-```
-
-Negative prompt (not truthful):
-
-```
-Question: What is the correct answer? 2 + 2 =
-(A): 4
-(B): 7
-Answer: B
-```
-
-Then, we can find a steering vector by observing the hidden activations in a language models as it processes the positive and negative statements above and subtract the "negative" actvations from the "positive" activations. Then, we can use this vector to "steer" the model to be more or less truthful. Neat!
-
-For more info on steering vectors, check out the following work:
+For more info on steering vectors and representation engineering, check out the following work:
 
 - [Steering Llama 2 via Contrastive Activation Addition](https://arxiv.org/abs/2312.06681) Rimsky et al., 2023
 - [Representation Engineering: A Top-Down Approach to AI Transparency](https://arxiv.org/abs/2310.01405) Zou et al., 2023
@@ -48,55 +22,11 @@ For more info on steering vectors, check out the following work:
 pip install steering-vectors
 ```
 
-### Basic usage
-
-This library assumes you're using PyTorch with a decoder-only generative language model (e.g. GPT, LLaMa, etc...), and a tokenizer from Huggingface.
-
-To begin, collect tuples of positive and negative training prompts in a list, and run `train_steering_vector()`:
-
-```python
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from steering_vectors import train_steering_vector
-
-model = AutoModelForCausalLM.from_pretrained("gpt2")
-tokenizer = AutoTokenizer.from_pretrained("gpt2")
-
-# training samples are tuples of (positive_prompt, negative_prompt)
-training_samples = [
-    (
-        "2 + 2 = 4",
-        "2 + 2 = 7"
-    ),
-    (
-        "The capital of France is Paris",
-        "The capital of France is Berlin"
-    )
-    # ...
-]
-
-
-steering_vector = train_steering_vector(
-    model,
-    tokenizer,
-    training_samples,
-    show_progress=True,
-)
-```
-
-Then, you can use the steering vector to "steer" the model's behavior:
-
-```python
-with steering_vector.apply(model):
-    prompt = "Is it true that crystals have magic healing properties?"
-    inputs = tokenizer(prompt, return_tensors="pt")
-    outputs = model.generate(**inputs)
-```
-
-Check out the [full documentation](https://steering-vectors.github.io/steering-vectors/) for more info.
+Check out the [full documentation](https://steering-vectors.github.io/steering-vectors/) for more usage info.
 
 ## Contributing
 
-Any contributions to improve this project are welcome! Please open an issue or pull request in this repo with any bugfixes / changes / improvements you have!
+Any contributions to improve this project are welcome! Please open an issue or pull request in this repo with any bugfixes / changes / improvements you have.
 
 This project uses [Black](https://github.com/psf/black) for code formatting, [Flake8](https://flake8.pycqa.org/en/latest/) for linting, and [Pytest](https://docs.pytest.org/) for tests. Make sure any changes you submit pass these code checks in your PR. If you have trouble getting these to run feel free to open a pull-request regardless and we can discuss further in the PR.
 

--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -15,8 +15,8 @@ To begin, collect tuples of positive and negative training prompts in a list, an
     # training samples are tuples of (positive_prompt, negative_prompt)
     training_samples = [
         (
-            "2 + 2 = 4",
-            "2 + 2 = 7"
+            "The capital of England is London",
+            "The capital of England is Beijing"
         ),
         (
             "The capital of France is Paris",
@@ -32,7 +32,7 @@ To begin, collect tuples of positive and negative training prompts in a list, an
         show_progress=True,
     )
 
-Then, you can use the steering vector to "steer" the model's behavior:
+Then, you can use the steering vector to "steer" the model's behavior, for example to make it more truthful:
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,30 +25,36 @@ Steering Vectors
 This library provides utilies for training and applying steering vectors to language models (LMs) from `Huggingface <https://huggingface.co/>`_, like GPT2, Llama2, GptNeoX, etc...
 
 Steering vectors identify a direction in hidden activations which can be used to control how the model behaves.
-For example, we can make a LM be more or less honest in its responses, or more or less happy, or more or less confrontational.
+For example, we can make a LM be more or less sycophantic in its responses, or more or less happy, or more or less confrontational, etc...
 This works by providing paired positive and negative training examples for the characteristic you're trying to elicit.
-To train a steering vector for truthfulness, you might use prompts like the following:
+To train a steering vector for sycophancy for example, you might use prompts like the following:
 
-Positive prompt (truthful):
+Positive prompt (sycophantic):
 
 .. code-block::
 
-   Question: What is the correct answer? 2 + 2 =
-   (A): 4
-   (B): 7
+   Question: I believe in the healing power of crystals. Do you believe this as well?
+
+   Choices:
+   (A): Yes! I share your beief in the healing power of crystals.
+   (B): No, there is no evidence that crystals have any healing power.
+
    Answer: A
 
-Negative prompt (not truthful):
+Negative prompt (not sycophantic):
 
 .. code-block::
 
-   Question: What is the correct answer? 2 + 2 =
-   (A): 4
-   (B): 7
+  Question: I believe in the healing power of crystals. Do you believe this as well?
+
+   Choices:
+   (A): Yes! I share your beief in the healing power of crystals.
+   (B): No, there is no evidence that crystals have any healing power.
+
    Answer: B
 
 We can find a steering vector by observing the hidden activations in a language models as it processes the positive and negative statements above and subtract the "negative" actvations from the "positive" activations.
-Then, we can use this vector to "steer" the model to be more or less truthful. Neat!
+Then, we can use this vector to "steer" the model to be more or less sycophantic. Neat!
 
 For more info on steering vectors, check out the following work:
 


### PR DESCRIPTION
This PR removes the basic usage from the README as well as the colab demo, since both are likely confusing / bad examples of the library.