### PR TITLE
chore: Replacing black/flake8/isort with ruff

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction
       - name: linting
-        run: poetry run ruff
+        run: poetry run ruff check
       - name: mypy type checking
         run: poetry run mypy .
       - name: pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,12 +14,8 @@ jobs:
           version: 1.4.0
       - name: Install dependencies
         run: poetry install --no-interaction
-      - name: flake8 linting
-        run: poetry run flake8 .
-      - name: isort linting
-        run: poetry run isort . --check-only --diff
-      - name: black code formatting
-        run: poetry run black . --check
+      - name: linting
+        run: poetry run ruff
       - name: mypy type checking
         run: poetry run mypy .
       - name: pytest

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Check out the [full documentation](https://steering-vectors.github.io/steering-v
 
 Any contributions to improve this project are welcome! Please open an issue or pull request in this repo with any bugfixes / changes / improvements you have.
 
-This project uses [Black](https://github.com/psf/black) for code formatting, [Flake8](https://flake8.pycqa.org/en/latest/) for linting, and [Pytest](https://docs.pytest.org/) for tests. Make sure any changes you submit pass these code checks in your PR. If you have trouble getting these to run feel free to open a pull-request regardless and we can discuss further in the PR.
+This project uses [Ruff](https://docs.astral.sh/ruff/) for code formatting and linting, [MyPy](https://mypy.readthedocs.io/en/stable/) for type checking, and [Pytest](https://docs.pytest.org/) for tests. Make sure any changes you submit pass these code checks in your PR. If you have trouble getting these to run feel free to open a pull-request regardless and we can discuss further in the PR.
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,27 @@ scikit-learn = "^1.4.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.8.0"
-black = "^23.12.1"
-isort = "^5.13.2"
 pytest = "^7.4.4"
 furo = "^2023.9.10"
 pygments = "^2.17.2"
 torch = "^2.1.2"
 protobuf = "^4.25.2"
-flake8 = "^7.0.0"
 sentencepiece = "^0.1.99"
 sphinx-autodoc-typehints = "^1.25.2"
-flake8-tidy-imports = "^4.10.0"
+ruff = "^0.2.2"
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+exclude = ["dist", "docs"]
+
+[tool.ruff.lint]
+extend-select = ["UP", "TID", "I", "F", "E"]
+ignore = ["E203", "E501", "E731"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.Union".msg = "Use `|` instead"
+"typing.Optional".msg = "Use `| None` instead"
+"typing.Dict".msg = "Use `dict` instead"
+"typing.List".msg = "Use `list` instead"
 
 [tool.semantic_release]
 version_variables = [

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -130,13 +130,13 @@ def train_steering_vector(
 
 
 def _formalize_batch(
-    batch: Sequence[SteeringVectorTrainingSample | tuple[str, str]]
+    batch: Sequence[SteeringVectorTrainingSample | tuple[str, str]],
 ) -> list[SteeringVectorTrainingSample]:
     return [_formalize_sample(sample) for sample in batch]
 
 
 def _formalize_sample(
-    sample: SteeringVectorTrainingSample | tuple[str, str]
+    sample: SteeringVectorTrainingSample | tuple[str, str],
 ) -> SteeringVectorTrainingSample:
     if isinstance(sample, tuple):
         return SteeringVectorTrainingSample(sample[0], sample[1])


### PR DESCRIPTION
This PR replaces black, flake8, and isort with ruff. Ruff does all the same things as these other libraries, but is written in rust and therefore more awesome.