### PR TITLE
hotfix to handle cases when activations are distributed across multiple gpus

### DIFF
--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -186,6 +186,29 @@ class SteeringVector:
         }
         return replace(self, layer_activations=layer_activations)
 
+    def dump(self, filepath: str) -> None:
+        """ 
+        Save layer_activations.
+        """
+        torch.save(
+            {   
+                "layer_activations": self.layer_activations,
+                "layer_type": self.layer_type,
+            },  
+            filepath,
+        )
+  
+    @classmethod
+    def load_from_file(cls, filepath: str) -> None:
+        """
+        Initialize layer_activations, layer_type from cached file.
+        """
+        cached = torch.load(filepath)
+        return cls(
+            layer_activations=cached["layer_activations"],
+            layer_type=cached["layer_type"],
+        )
+        
 
 def _create_additive_hook(
     target_activation: Tensor,

--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -186,29 +186,6 @@ class SteeringVector:
         }
         return replace(self, layer_activations=layer_activations)
 
-    def dump(self, filepath: str) -> None:
-        """ 
-        Save layer_activations.
-        """
-        torch.save(
-            {   
-                "layer_activations": self.layer_activations,
-                "layer_type": self.layer_type,
-            },  
-            filepath,
-        )
-  
-    @classmethod
-    def load_from_file(cls, filepath: str) -> None:
-        """
-        Initialize layer_activations, layer_type from cached file.
-        """
-        cached = torch.load(filepath)
-        return cls(
-            layer_activations=cached["layer_activations"],
-            layer_type=cached["layer_type"],
-        )
-        
 
 def _create_additive_hook(
     target_activation: Tensor,

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -245,8 +245,8 @@ def _extract_activations(
         model(**input.to(model.device))
     for layer_num, activation in record.items():
         results[layer_num] = activation[-1][
-            batch_indices.to(activations[-1].device),
-            adjusted_read_indices.to(activations[-1].device)
+            batch_indices.to(activation[-1].device),
+            adjusted_read_indices.to(activation[-1].device)
         ].detach()
     return results
 

--- a/steering_vectors/train_steering_vector.py
+++ b/steering_vectors/train_steering_vector.py
@@ -236,7 +236,7 @@ def _extract_activations(
     input = tokenizer(prompts, return_tensors="pt", padding=True)
     adjusted_read_indices = adjust_read_indices_for_padding(
         torch.tensor(read_token_indices), input["attention_mask"]
-    ).to(model.device)
+    )
     batch_indices = torch.arange(len(prompts))
     results = {}
     with record_activations(
@@ -245,7 +245,8 @@ def _extract_activations(
         model(**input.to(model.device))
     for layer_num, activation in record.items():
         results[layer_num] = activation[-1][
-            batch_indices, adjusted_read_indices
+            batch_indices.to(activations[-1].device),
+            adjusted_read_indices.to(activations[-1].device)
         ].detach()
     return results
 


### PR DESCRIPTION
In the case in which I initialize a mode as following:

```
model = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto")
```

in which I have > 1 gpus, the model weights (and eventually its activations) get loaded across gpus.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved accuracy in the extraction process of steering vectors by adjusting padding indices and ensuring correct device placements.
- **New Features**
	- Added methods to save and load `layer_activations` and `layer_type` in the steering vector module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->