### PR TITLE
chore: run CI on PRs, not just push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   lint_test_and_build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It looks like CI didn't run on #40, which is likely due to CI specifying only to run on push, not pull_request as well. This PR adds an action to run on pull_request.