### PR TITLE
feat: adding ablation operator helpers

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -36,6 +36,31 @@ when calling ``steering_vector.apply()`` or ``steering_vector.patch()``, like be
         model.forward(...)
 
 
+There are some built-in operators as well to help with common steering scenarios. To ablate the steering vector entirely
+from the activation, you can use the ``ablation_operator()``. This will ensure that projection of the steering vector is
+fully erase from the activation.
+
+.. code-block:: python
+
+    from steering_vectors import ablation_operator
+
+    with steering_vec.apply(model, operator=ablation_operator()):
+        # do something with the model
+        model.forward(...)
+
+If you want to first ablate the steering vector from the activation vector and then add it in with a set multiplier, you
+can use the ``ablation_then_addition_operator()``. This will guarantee that the projection of the activation along the
+steering direction is exactly equal to the steering vector.
+
+.. code-block:: python
+
+    from steering_vectors import ablation_then_addition_operator
+
+    with steering_vec.apply(model, operator=ablation_then_addition_operator()):
+        # do something with the model
+        model.forward(...)
+
+
 Custom aggregators
 ''''''''''''''''''
 

--- a/steering_vectors/__init__.py
+++ b/steering_vectors/__init__.py
@@ -14,6 +14,11 @@ from .layer_matching import (
     guess_and_enhance_layer_config,
 )
 from .record_activations import record_activations
+from .steering_operators import (
+    ablation_operator,
+    ablation_then_addition_operator,
+    addition_operator,
+)
 from .steering_vector import PatchDeltaOperator, SteeringPatchHandle, SteeringVector
 from .train_steering_vector import (
     SteeringVectorTrainingSample,
@@ -40,4 +45,7 @@ __all__ = [
     "SteeringVectorTrainingSample",
     "aggregate_activations",
     "extract_activations",
+    "ablation_operator",
+    "addition_operator",
+    "ablation_then_addition_operator",
 ]

--- a/steering_vectors/steering_operators.py
+++ b/steering_vectors/steering_operators.py
@@ -1,0 +1,51 @@
+import torch
+
+from steering_vectors.steering_vector import PatchDeltaOperator
+
+
+def addition_operator() -> PatchDeltaOperator:
+    """
+    Simply add the steering vector to the activation. This is the default
+    """
+
+    def _addition_operator(
+        _original_activation: torch.Tensor, steering_vector: torch.Tensor
+    ) -> torch.Tensor:
+        return steering_vector
+
+    return _addition_operator
+
+
+def ablation_operator() -> PatchDeltaOperator:
+    """
+    Erase the projection of the steering vector entirely from activation.
+    NOTE: This will ignore the steering vector multiplier param, and will always
+    erase the steering vector entirely from the activation.
+    """
+
+    def _ablation_operator(
+        original_activation: torch.Tensor, steering_vector: torch.Tensor
+    ) -> torch.Tensor:
+        norm_vec = steering_vector / torch.norm(steering_vector)
+        return -1 * norm_vec * (norm_vec.T @ original_activation)
+
+    return _ablation_operator
+
+
+def ablation_then_addition_operator() -> PatchDeltaOperator:
+    """
+    This acts as a combination of the ablation and addition operators. It first removes the
+    projection of the steering vector from the activation, and then adds the steering vector
+    """
+
+    _ablation_operator = ablation_operator()
+    _addition_operator = addition_operator()
+
+    def _ablation_then_addition_operator(
+        original_activation: torch.Tensor, steering_vector: torch.Tensor
+    ) -> torch.Tensor:
+        ablation_delta = _ablation_operator(original_activation, steering_vector)
+        addition_delta = _addition_operator(original_activation, steering_vector)
+        return ablation_delta + addition_delta
+
+    return _ablation_then_addition_operator

--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -196,10 +196,10 @@ def _create_additive_hook(
 
     def hook_fn(_m: Any, _inputs: Any, outputs: Any) -> Any:
         original_tensor = untuple_tensor(outputs)
-        act = target_activation.to(original_tensor.device)
-        delta = act
+        target_act = target_activation.to(original_tensor.device)
+        delta = target_act
         if operator is not None:
-            delta = operator(original_tensor, act)
+            delta = operator(original_tensor, target_act)
         if isinstance(token_indices, Tensor):
             mask = token_indices
         else:

--- a/tests/test_steering_operators.py
+++ b/tests/test_steering_operators.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from steering_vectors.steering_operators import (
+    ablation_operator,
+    ablation_then_addition_operator,
+    addition_operator,
+)
+
+
+def test_ablation_operator_removes_the_projection_of_the_steering_vec() -> None:
+    act = torch.randn(30)
+    steering_vec = torch.randn(30)
+    operator = ablation_operator()
+    delta = operator(act, steering_vec)
+    steered_act = act + delta
+
+    assert steered_act @ steering_vec == pytest.approx(0, abs=1e-6)
+
+
+def test_addition_operator_acts_as_identity() -> None:
+    act = torch.randn(30)
+    steering_vec = torch.randn(30)
+    operator = addition_operator()
+    delta = operator(act, steering_vec)
+    assert torch.allclose(delta, steering_vec)
+
+
+def test_ablation_then_addition_operator_applies_both_ablation_and_addition() -> None:
+    act = torch.randn(30)
+    steering_vec = 5 * torch.randn(30)
+    operator = ablation_then_addition_operator()
+    delta = operator(act, steering_vec)
+    steered_act = act + delta
+
+    steering_vec_dir = steering_vec / torch.norm(steering_vec)
+
+    # the component on the resulting activation on the steering direction should match the steering vector
+    assert steered_act @ steering_vec_dir == pytest.approx(
+        steering_vec.norm(), abs=1e-5
+    )


### PR DESCRIPTION
This PR adds helpers to steer with ablation. Specifically, the following operator helpers are added:

- `ablation_operator`: This removes the projection of the steering vector from the activation
- `ablation_then_addition_operator`: This first applies ablation, then adds the steering vector into the target activation to better control the exact magnitude of the projection of the steering vector on the activation.