### PR TITLE
feat: support steering when using batching + right padding

### DIFF
--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -203,7 +203,11 @@ def _create_additive_hook(
         else:
             mask = torch.zeros(original_tensor.shape[1])
             mask[token_indices] = 1
-        mask = mask.reshape(1, -1, 1)
+        mask = (
+            mask.reshape(1, -1, 1)
+            if len(mask.shape) == 1
+            else mask.reshape(mask.shape[0], -1, 1)
+        )
         mask = mask.to(original_tensor.device)
         original_tensor[None] = original_tensor + (mask * delta)
         return outputs


### PR DESCRIPTION
Previously, a mask passed to `steering_vector.apply` could only be 1d and of the same length as the sequence length. However, when applying a steering vector to batched inputs, one may want to mask at different token positions for different elements of the batch. For example, when steering at the last token of a sequence, this token can have a different index for different sequences in a batch if the sequences are not all of the same length.

This PR adds support for passing masks of shape (batch, seq) to the `token_indices` argument of `steering_vector.apply`. It also adds a unit test that demonstrates and tests this functionality.