### PR TITLE
fix: fixing pypi release with pdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ version_variables = [
     "pyproject.toml:version",
 ]
 branch = "main"
+build_command = "pip install pdm && pdm build"
 
 [tool.pdm]
 [tool.pdm.dev-dependencies]
@@ -57,8 +58,6 @@ dev = [
     "pytest-cov<6.0.0,>=5.0.0",
 ]
 
-[tool.pdm.build]
-includes = []
 [build-system]
 requires = ["pdm-backend"]
 build-backend = "pdm.backend"


### PR DESCRIPTION
(hopefully) fixing the PyPI deploy, since this appears to have been broken by #48, where [build_command was deleted](https://github.com/steering-vectors/steering-vectors/pull/48/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L55).