### PR TITLE
fix: fixing skipping negative layer indices

### DIFF
--- a/steering_vectors/record_activations.py
+++ b/steering_vectors/record_activations.py
@@ -50,7 +50,7 @@ def record_activations(
     matching_layers = collect_matching_layers(model, matcher)
     hooks: list[RemovableHandle] = []
     for layer_num, layer_name in enumerate(matching_layers):
-        if layer_nums is not None and layer_num not in layer_nums:
+        if layer_nums is not None and layer_num not in layer_nums and (layer_num - len(matching_layers)) not in layer_nums:
             continue
         module = get_module(model, layer_name)
         hook_fn = _create_read_hook(

--- a/steering_vectors/record_activations.py
+++ b/steering_vectors/record_activations.py
@@ -50,7 +50,11 @@ def record_activations(
     matching_layers = collect_matching_layers(model, matcher)
     hooks: list[RemovableHandle] = []
     for layer_num, layer_name in enumerate(matching_layers):
-        if layer_nums is not None and layer_num not in layer_nums and (layer_num - len(matching_layers)) not in layer_nums:
+        if (
+            layer_nums is not None
+            and layer_num not in layer_nums
+            and (layer_num - len(matching_layers)) not in layer_nums
+        ):
             continue
         module = get_module(model, layer_name)
         hook_fn = _create_read_hook(

--- a/tests/test_record_activations.py
+++ b/tests/test_record_activations.py
@@ -17,3 +17,23 @@ def test_record_activations_matches_decoder_hidden_states(
         list(recorded_activations.values())[:-1], hidden_states[1:-1]
     ):
         assert torch.equal(recorded_activation[0], hidden_state)
+
+
+def test_record_activations_positive_vs_negative_indices(
+    model: GPT2LMHeadModel, tokenizer: PreTrainedTokenizer
+) -> None:
+    positive_layer_nums = [11, 9]  # positive layer indices
+    negative_layer_nums = [-1, -3]  # corresponding negative layer indices
+
+    with record_activations(model, layer_nums=positive_layer_nums) as recorded_activations_positive:
+        inputs = tokenizer("Hello world", return_tensors="pt")
+        model(**inputs)
+
+    with record_activations(model, layer_nums=negative_layer_nums) as recorded_activations_negative:
+        inputs = tokenizer("Hello world", return_tensors="pt")
+        model(**inputs)
+
+    assert list(recorded_activations_positive.keys()) == list(recorded_activations_negative.keys())
+
+    for key in recorded_activations_positive.keys():
+        assert torch.equal(recorded_activations_positive[key][0], recorded_activations_negative[key][0])

--- a/tests/test_record_activations.py
+++ b/tests/test_record_activations.py
@@ -25,15 +25,23 @@ def test_record_activations_positive_vs_negative_indices(
     positive_layer_nums = [11, 9]  # positive layer indices
     negative_layer_nums = [-1, -3]  # corresponding negative layer indices
 
-    with record_activations(model, layer_nums=positive_layer_nums) as recorded_activations_positive:
+    with record_activations(
+        model, layer_nums=positive_layer_nums
+    ) as recorded_activations_positive:
         inputs = tokenizer("Hello world", return_tensors="pt")
         model(**inputs)
 
-    with record_activations(model, layer_nums=negative_layer_nums) as recorded_activations_negative:
+    with record_activations(
+        model, layer_nums=negative_layer_nums
+    ) as recorded_activations_negative:
         inputs = tokenizer("Hello world", return_tensors="pt")
         model(**inputs)
 
-    assert list(recorded_activations_positive.keys()) == list(recorded_activations_negative.keys())
+    assert list(recorded_activations_positive.keys()) == list(
+        recorded_activations_negative.keys()
+    )
 
     for key in recorded_activations_positive.keys():
-        assert torch.equal(recorded_activations_positive[key][0], recorded_activations_negative[key][0])
+        assert torch.equal(
+            recorded_activations_positive[key][0], recorded_activations_negative[key][0]
+        )


### PR DESCRIPTION
The documentation says that negative indices work, but the code that checks whether to skip a layer works with enumerate so it wasn't checking for negative indices. I added one more condition that checks if there are negative numbers in the layer index list.