### PR TITLE
chore: fixing formatting for new ruff version

### DIFF
--- a/steering_vectors/steering_vector.py
+++ b/steering_vectors/steering_vector.py
@@ -73,9 +73,9 @@ class SteeringVector:
             >>> model.forward(...)
             >>> handle.remove()
         """
-        assert (min_token_index is None) or (
-            token_indices is None
-        ), "Can not pass both min_token_index and token_indices"
+        assert (min_token_index is None) or (token_indices is None), (
+            "Can not pass both min_token_index and token_indices"
+        )
         if isinstance(token_indices, Tensor):
             assert torch.all(
                 torch.logical_or(token_indices == 0, token_indices == 1)

--- a/tests/_original_caa/helpers.py
+++ b/tests/_original_caa/helpers.py
@@ -165,4 +165,4 @@ def get_a_b_probs(logits, a_token_id, b_token_id):
 
 
 def make_tensor_save_suffix(layer, model_name_path):
-    return f'{layer}_{model_name_path.split("/")[-1]}'
+    return f"{layer}_{model_name_path.split('/')[-1]}"


### PR DESCRIPTION
It looks like CI is failing due to formatting, likely because of some changes in new versions of ruff. This PR just reruns the formatter to fix this.